### PR TITLE
Raise exception classes instead of strings

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,4 @@
+module EXIFR
+  class MalformedJPEG < StandardError; end
+  class NoMarkersFound < StandardError; end
+end

--- a/lib/exifr.rb
+++ b/lib/exifr.rb
@@ -2,3 +2,4 @@
 
 require 'jpeg'
 require 'tiff'
+require 'exceptions'

--- a/lib/jpeg.rb
+++ b/lib/jpeg.rb
@@ -86,14 +86,14 @@ module EXIFR
         end
       end unless io.respond_to? :readsof
 
-      raise 'malformed JPEG' unless io.readbyte == 0xFF && io.readbyte == 0xD8 # SOI
+      raise MalformedJPEG unless io.readbyte == 0xFF && io.readbyte == 0xD8 # SOI
 
       app1s = []
       while marker = io.next
         case marker
           when 0xC0..0xC3, 0xC5..0xC7, 0xC9..0xCB, 0xCD..0xCF # SOF markers
             length, @bits, @height, @width, components = io.readsof
-            raise 'malformed JPEG' unless length == 8 + components * 3
+            raise MalformedJPEG unless length == 8 + components * 3
           when 0xD9, 0xDA;  break # EOI, SOS
           when 0xFE;        (@comment ||= []) << io.readframe # COM
           when 0xE1;        app1s << io.readframe # APP1, may contain EXIF tag

--- a/lib/tiff.rb
+++ b/lib/tiff.rb
@@ -511,7 +511,7 @@ module EXIFR
       def sign_byte(n)
         (n & 0x80) != 0 ? n - 0x100 : n
       end
-      
+
       def sign_short(n)
         (n & 0x8000) != 0 ? n - 0x10000 : n
       end
@@ -540,7 +540,7 @@ module EXIFR
         case self[0..1]
         when 'II'; @short, @long = 'v', 'V'
         when 'MM'; @short, @long = 'n', 'N'
-        else; raise 'no II or MM marker found'
+        else; raise NoMarkersFound
         end
       end
 


### PR DESCRIPTION
This patch adds exception classes to allow rescuing from raised exceptions -- can't rescue from strings.  In my case I needed to gracefully handle malformed JPEGs.
