### PR TITLE
Fix warnings about uninitialized @comment

### DIFF
--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -108,7 +108,7 @@ module EXIFR
         end
       end
 
-      @comment = @comment.first if @comment && @comment.size == 1
+      @comment = @comment.first if defined?(@comment) && @comment.size == 1
 
       if app1 = @app1s.find { |d| d[0..5] == "Exif\0\0" }
         @exif_data = app1[6..-1]


### PR DESCRIPTION
I was writing a script with exifr--nice gem--and I got a lot of warnings in my output:

```
/opt/local/lib/ruby/gems/1.8/gems/exifr-1.0.6/lib/exifr/jpeg.rb:111: warning: instance variable @comment not initialized
/opt/local/lib/ruby/gems/1.8/gems/exifr-1.0.6/lib/exifr/jpeg.rb:111: warning: instance variable @comment not initialized
/opt/local/lib/ruby/gems/1.8/gems/exifr-1.0.6/lib/exifr/jpeg.rb:111: warning: instance variable @comment not initialized
```

The offending line in jpef.rb is:

```
@comment = @comment.first if @comment && @comment.size == 1
```

`puts @foo if @foo` will cause a warning, so I changed this to check if @comment is defined. Another possible solution would be to initialize @comment set to nil.
