### PR TITLE
Fix for time_proc, methods like date_time should return time in UTC

### DIFF
--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -241,7 +241,7 @@ module EXIFR
     time_proc = proc do |value|
       value.map do |value|
         if value =~ /^(\d{4}):(\d\d):(\d\d) (\d\d):(\d\d):(\d\d)$/
-          Time.mktime($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i) rescue nil
+          Time.utc($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i) rescue nil
         else
           value
         end

--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -94,6 +94,13 @@ class JPEGTest < Test::Unit::TestCase
     assert_kind_of Rational, j.f_number
   end
 
+  def test_exif_date_time_in_utc
+    j = JPEG.new(f('exif.jpg'))
+    assert_kind_of Time, j.date_time
+    assert j.date_time.utc?, "date_time should returns time in UTC"
+  end
+
+
   def test_no_method_error
     assert_nothing_raised { JPEG.new(f('image.jpg')).f_number }
     assert_raise(NoMethodError) { JPEG.new(f('image.jpg')).foo }


### PR DESCRIPTION
According to http://www.exif.org/Exif2-2.PDF
UTC is not obligatory from the spec but this should help to avoid problem with time zones .
