### PR TITLE
use UTC

### DIFF
--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -241,7 +241,7 @@ module EXIFR
     time_proc = proc do |value|
       value.map do |value|
         if value =~ /^(\d{4}):(\d\d):(\d\d) (\d\d):(\d\d):(\d\d)$/
-          Time.mktime($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i) rescue nil
+          Time.utc($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i) rescue nil
         else
           value
         end


### PR DESCRIPTION
Since exif does not store timezone info, have to use utc.
