### PR TITLE
Adds support for Time.zone via ActiveSupport::TimeWithZone

### DIFF
--- a/exifr.gemspec
+++ b/exifr.gemspec
@@ -14,5 +14,7 @@ spec = Gem::Specification.new do |s|
   s.rdoc_options = ['--title', 'EXIF Reader for Ruby API Documentation', '--main', 'README.rdoc']
   s.extra_rdoc_files = %w(README.rdoc CHANGELOG)
 
+  s.add_runtime_dependency 'activesupport'
+
   s.executables = %w(exifr)
 end

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -3,6 +3,7 @@
 require 'exifr'
 require 'rational'
 require 'enumerator'
+require 'active_support/time_with_zone'
 
 module EXIFR
   # = TIFF decoder
@@ -241,7 +242,7 @@ module EXIFR
     time_proc = proc do |value|
       value.map do |value|
         if value =~ /^(\d{4}):(\d\d):(\d\d) (\d\d):(\d\d):(\d\d)$/
-          Time.mktime($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i) rescue nil
+          Time.new($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, Time.zone.formatted_offset) rescue nil
         else
           value
         end


### PR DESCRIPTION
Because EXIF does not include timezone information, the user should be able to set what timezone the times are parsed in. ActiveSupport has a nice way to do this:

``` ruby
Time.use_zone('UTC') { exif = EXIFR::JPEG.new 'image.jpeg' }
```
