### PR TITLE
Fix `respond_to?` signature

### DIFF
--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -61,8 +61,8 @@ module EXIFR
       @exif.send method if defined?(@exif) && @exif
     end
 
-    def respond_to?(method) # :nodoc:
-      super || methods.include?(method.to_s)
+    def respond_to?(method, include_all = false) # :nodoc:
+      super || methods.include?(method.to_s) || (include_all && private_methods.include?(method))
     end
 
     def methods # :nodoc:

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -414,9 +414,9 @@ module EXIFR
       end
     end
 
-    def respond_to?(method) # :nodoc:
+    def respond_to?(method, include_all = false) # :nodoc:
       super ||
-        (defined?(@ifds) && @ifds && @ifds.first && @ifds.first.respond_to?(method)) ||
+        (defined?(@ifds) && @ifds && @ifds.first && @ifds.first.respond_to?(method, include_all)) ||
         TAGS.include?(method.to_s)
     end
 


### PR DESCRIPTION
Context
-------

Our app is littered with warnings like:

```
/var/lib/[...]/vendor/bundle/ruby/2.3.0/gems/exifr-1.2.3.1/lib/exifr/jpeg.rb:52: warning: EXIFR::TIFF#respond_to?(:to_hash) is old fashion which takes only one parameter
```

Change
------

Match the signature in the docs since at least 1.8.7
(http://ruby-doc.org/core-1.8.7/Object.html#method-i-respond_to-3F).