### PR TITLE
Having stringified methods is not a good idea

### DIFF
--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -57,22 +57,22 @@ module EXIFR
     # +method+ does exist for EXIF data +nil+ will be returned.
     def method_missing(method, *args)
       super unless args.empty?
-      super unless methods.include?(method.to_s)
+      super unless methods.include?(method)
       @exif.send method if defined?(@exif) && @exif
     end
 
     def respond_to?(method, include_all = false) # :nodoc:
-      super || methods.include?(method.to_s) || (include_all && private_methods.include?(method))
+      super || methods.include?(method) || (include_all && private_methods.include?(method))
     end
 
     def methods # :nodoc:
-      super + TIFF::TAGS << "gps"
+      super + TIFF::TAGS << :gps
     end
 
     class << self
       alias instance_methods_without_jpeg_extras instance_methods
       def instance_methods(include_super = true) # :nodoc:
-        instance_methods_without_jpeg_extras(include_super) + TIFF::TAGS << "gps"
+        instance_methods_without_jpeg_extras(include_super) + TIFF::TAGS << :gps
       end
     end
 

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -169,7 +169,7 @@ module EXIFR
         0x927c => :maker_note,
         0x9286 => :user_comment,
         0x9290 => :subsec_time,
-        0x9291 => :subsec_time_orginal,
+        0x9291 => :subsec_time_original,
         0x9292 => :subsec_time_digitized,
         0xa000 => :flashpix_version,
         0xa001 => :color_space,

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -366,7 +366,7 @@ module EXIFR
                     })
 
     # Names for all recognized TIFF fields.
-    TAGS = ([TAG_MAPPING.keys, TAG_MAPPING.values.map{|v|v.values}].flatten.uniq - IFD_TAGS).map{|v|v.to_s}
+    TAGS = [TAG_MAPPING.keys, TAG_MAPPING.values.map{|v|v.values}].flatten.uniq - IFD_TAGS
 
     # +file+ is a filename or an +IO+ object.  Hint: use +StringIO+ when working with slurped data like blobs.
     def initialize(file)
@@ -407,7 +407,7 @@ module EXIFR
 
       if @ifds.first.respond_to?(method)
         @ifds.first.send(method)
-      elsif TAGS.include?(method.to_s)
+      elsif TAGS.include?(method)
         @ifds.first.to_hash[method]
       else
         super
@@ -417,7 +417,7 @@ module EXIFR
     def respond_to?(method, include_all = false) # :nodoc:
       super ||
         (defined?(@ifds) && @ifds && @ifds.first && @ifds.first.respond_to?(method, include_all)) ||
-        TAGS.include?(method.to_s)
+        TAGS.include?(method)
     end
 
     def methods # :nodoc:
@@ -477,7 +477,7 @@ module EXIFR
       end
 
       def method_missing(method, *args)
-        super unless args.empty? && TAGS.include?(method.to_s)
+        super unless args.empty? && TAGS.include?(method)
         to_hash[method]
       end
 

--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -78,11 +78,9 @@ class JPEGTest < TestCase
 
   def test_exif_dispatch
     j = JPEG.new(f('exif.jpg'))
-
-    assert JPEG.instance_methods.include?('date_time')
-    assert j.methods.include?('date_time')
+    JPEG.instance_methods.include?(:date_time)
+    assert j.methods.include?(:date_time)
     assert j.respond_to?(:date_time)
-    assert j.respond_to?('date_time')
     assert j.date_time
     assert_kind_of Time, j.date_time
 

--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -78,7 +78,7 @@ class JPEGTest < TestCase
 
   def test_exif_dispatch
     j = JPEG.new(f('exif.jpg'))
-    JPEG.instance_methods.include?(:date_time)
+    assert JPEG.instance_methods.include?(:date_time)
     assert j.methods.include?(:date_time)
     assert j.respond_to?(:date_time)
     assert j.date_time

--- a/tests/tiff_test.rb
+++ b/tests/tiff_test.rb
@@ -16,7 +16,7 @@ class TIFFTest < TestCase
       assert TIFF.new(StringIO.new(File.read(fname)))
     end
   end
-  
+
   def test_raises_malformed_tiff
     begin
       TIFF.new(StringIO.new("djibberish"))
@@ -120,9 +120,8 @@ class TIFFTest < TestCase
 
   def test_ifd_dispatch
     assert @t.respond_to?(:f_number)
-    assert @t.respond_to?('f_number')
-    assert @t.methods.include?('f_number')
-    assert TIFF.instance_methods.include?('f_number')
+    assert @t.methods.include?(:f_number)
+    assert TIFF.instance_methods.include?(:f_number)
 
     assert @t.f_number
     assert_kind_of Rational, @t.f_number
@@ -186,7 +185,7 @@ class TIFFTest < TestCase
   def test_handle_out_of_range_offset
     assert_equal 'NIKON', TIFF.new(f('out-of-range.exif')).make
   end
-  
+
   def test_negative_exposure_bias_value
     assert_equal(-1.quo(3), TIFF.new(f('negative-exposure-bias-value.exif')).exposure_bias_value)
   end


### PR DESCRIPTION
When doing `instance.methods.sort` I got an error about `Symbol` to `String` comparison. So I created this PR to not have those methods included to `methods`, `instance_methods` or `respond_to?` as `String`s.