### PR TITLE
Avoid ruby warnings - take 2

### DIFF
--- a/lib/exifr.rb
+++ b/lib/exifr.rb
@@ -1,15 +1,4 @@
 # Copyright (c) 2006-2015 - R.W. van 't Veer
 
-require 'logger'
-
-module EXIFR
-  class MalformedImage < StandardError; end
-  class MalformedJPEG < MalformedImage; end
-  class MalformedTIFF < MalformedImage; end
-
-  class << self; attr_accessor :logger; end
-  self.logger = Logger.new(STDERR)
-end
-
 require 'exifr/jpeg'
 require 'exifr/tiff'

--- a/lib/exifr/common.rb
+++ b/lib/exifr/common.rb
@@ -1,0 +1,12 @@
+# Copyright (c) 2006-2015 - R.W. van 't Veer
+
+require 'logger'
+
+module EXIFR
+  class MalformedImage < StandardError; end
+  class MalformedJPEG < MalformedImage; end
+  class MalformedTIFF < MalformedImage; end
+
+  class << self; attr_accessor :logger; end
+  self.logger = Logger.new(STDERR)
+end

--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -1,6 +1,7 @@
 # Copyright (c) 2006-2015 - R.W. van 't Veer
 
-require 'exifr'
+require 'exifr/common'
+require 'exifr/tiff'
 require 'stringio'
 require 'delegate'
 

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -1,6 +1,6 @@
 # Copyright (c) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 - R.W. van 't Veer
 
-require 'exifr'
+require 'exifr/common'
 require 'rational'
 require 'enumerator'
 

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2015 - R.W. van 't Veer
+# Copyright (c) 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 - R.W. van 't Veer
 
 require 'exifr'
 require 'rational'
@@ -245,16 +245,16 @@ module EXIFR
     self.mktime_proc = proc { |*args| Time.local(*args) }
 
     time_proc = proc do |value|
-      value.map do |value|
-        if value =~ /^(\d{4}):(\d\d):(\d\d) (\d\d):(\d\d):(\d\d)$/
+      value.map do |v|
+        if v =~ /^(\d{4}):(\d\d):(\d\d) (\d\d):(\d\d):(\d\d)$/
           begin
             mktime_proc.call($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i)
           rescue => ex
-            EXIFR.logger.warn("Bad date/time value #{value.inspect}: #{ex}")
+            EXIFR.logger.warn("Bad date/time value #{v.inspect}: #{ex}")
             nil
           end
         else
-          value
+          v
         end
       end
     end
@@ -356,13 +356,13 @@ module EXIFR
                       :date_time_original => time_proc,
                       :date_time_digitized => time_proc,
                       :date_time => time_proc,
-                      :orientation => proc { |v| v.map{|v| ORIENTATIONS[v]} },
+                      :orientation => proc { |x| x.map{|y| ORIENTATIONS[y]} },
                       :gps_latitude => degrees_proc,
                       :gps_longitude => degrees_proc,
                       :gps_dest_latitude => degrees_proc,
                       :gps_dest_longitude => degrees_proc,
-                      :shutter_speed_value => proc { |v| v.map { |v| v.abs < 100 ? rational(1, (2 ** v).to_i) : nil } },
-                      :aperture_value => proc { |v| v.map { |v| round(1.4142 ** v, 1) } }
+                      :shutter_speed_value => proc { |x| x.map { |y| y.abs < 100 ? rational(1, (2 ** y).to_i) : nil } },
+                      :aperture_value => proc { |x| x.map { |y| round(1.4142 ** y, 1) } }
                     })
 
     # Names for all recognized TIFF fields.
@@ -377,9 +377,9 @@ module EXIFR
           @ifds << ifd
         end
 
-        @jpeg_thumbnails = @ifds.map do |ifd|
-          if ifd.jpeg_interchange_format && ifd.jpeg_interchange_format_length
-            start, length = ifd.jpeg_interchange_format, ifd.jpeg_interchange_format_length
+        @jpeg_thumbnails = @ifds.map do |v|
+          if v.jpeg_interchange_format && v.jpeg_interchange_format_length
+            start, length = v.jpeg_interchange_format, v.jpeg_interchange_format_length
             data[start..(start + length)]
           end
         end.compact

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -424,6 +424,14 @@ module EXIFR
       (super + TAGS + IFD.instance_methods(false)).uniq
     end
 
+    def encode_with(coder)
+      coder["ifds"] = @ifds
+    end
+
+    def to_yaml_properties
+      ['@ifds']
+    end
+
     class << self
       alias instance_methods_without_tiff_extras instance_methods
       def instance_methods(include_super = true) # :nodoc:
@@ -506,6 +514,10 @@ module EXIFR
 
       def next
         IFD.new(@data, @offset_next) if next?
+      end
+
+      def encode_with(coder)
+        coder["fields"] = @fields
       end
 
       def to_yaml_properties


### PR DESCRIPTION
I found that lib/exifr/jpeg.rb doesn't need to require exifr. Removing that eliminates the circular require. The same goes for lib/exifr/tiff.rb. Not sure if I'm missing anything, because https://github.com/remvee/exifr/pull/36 doesn't do this. The tests say everything is good though.

I also took the liberty to cherry pick 2 other fixes from https://github.com/remvee/exifr/pull/36. The tests are now really happy:

```
rake
Run options: --seed 64684

# Running:

.................................

Finished in 0.223494s, 147.6547 runs/s, 14931.0244 assertions/s.

33 runs, 3337 assertions, 0 failures, 0 errors, 0 skips
```

How does this look?