### PR TITLE
Set up Bundler to simplify running the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /doc/
 .rbx
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -50,6 +50,11 @@ Or when the application depends on ActiveSupport for time zone handling:
 If you need to access XMP data you can use the xmp gem.  More info and
 examples at https://github.com/amberbit/xmp
 
+== Development and running tests
+
+On a fresh checkout of the repository, run `bundle install` and then
+`bundle exec rake test`
+
 == Author
 R.W. van 't Veer
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ dependencies:
 
 test:
   override:
-    - rvm 1.8.7 do rake test
-    - rvm 1.9.2,1.9.3 do rake test
-    - rvm 2.0,2.1,2.2,2.3.1,2.4.1 do rake test
-    - rvm jruby-1.7,jruby-9.0 do rake test
+    - rvm 1.8.7 do bundle install; bundle exec rake test
+    - rvm 1.9.2,1.9.3 do bundle install; bundle exec rake test
+    - rvm 2.0,2.1,2.2,2.3.1,2.4.1 do bundle install; bundle exec rake test
+    - rvm jruby-1.7,jruby-9.0 do bundle install; bundle exec rake test

--- a/exifr.gemspec
+++ b/exifr.gemspec
@@ -18,4 +18,9 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.rdoc CHANGELOG)
 
   s.executables = %w(exifr)
+
+  if s.respond_to?(:add_development_dependency)
+    s.add_development_dependency "test-unit", '3.1.5'
+    s.add_development_dependency "rake", '~> 10'
+  end
 end


### PR DESCRIPTION
The combination of "all the Rubies" requires a fairly specific combo of Rake and test-unit versions to be viable. This commit  adds Rake and test-unit as development dependencies, with a tight scope on test-unit version. It allows running `rake test` via Bundler with a guarantee on a viable combination of versions. Gemfile is not included in the .gemspec so should not be packaged with the gem on build, neither does the .gemspec include `bundler` as a dev dep - this is not needed unless one has to use the Bundler rake tasks to do release management.