### PR TITLE
Modernize #methods method signatures

### DIFF
--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -66,8 +66,12 @@ module EXIFR
       super || methods.include?(method) || (include_all && private_methods.include?(method))
     end
 
-    def methods # :nodoc:
-      super + TIFF::TAGS << :gps
+    def methods(regular=true) # :nodoc:
+      if regular
+        super + TIFF::TAGS << :gps
+      else
+        super
+      end
     end
 
     class << self

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -423,8 +423,12 @@ module EXIFR
         TAGS.include?(method)
     end
 
-    def methods # :nodoc:
-      (super + TAGS + IFD.instance_methods(false)).uniq
+    def methods(regular=true) # :nodoc:
+      if regular
+        (super + TAGS + IFD.instance_methods(false)).uniq
+      else
+        super
+      end
     end
 
     def encode_with(coder)

--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -103,6 +103,13 @@ class JPEGTest < TestCase
     end
   end
 
+  def test_methods_method
+    j = JPEG.new(f('exif.jpg'))
+    assert j.methods.include?(:date_time)
+    assert j.methods(true).include?(:date_time)
+    refute j.methods(false).include?(:date_time)
+  end
+
   def test_multiple_app1
     assert JPEG.new(f('multiple-app1.jpg')).exif?
   end

--- a/tests/tiff_test.rb
+++ b/tests/tiff_test.rb
@@ -199,4 +199,11 @@ class TIFFTest < TestCase
   def test_nul_terminated_strings
     assert_equal 'GoPro', TIFF.new(f('gopro_hd2.exif')).make
   end
+
+  def test_methods_method
+    t = TIFF.new(f('gopro_hd2.exif'))
+    assert t.methods.include?(:make)
+    assert t.methods(true).include?(:make)
+    refute t.methods(false).include?(:make)
+  end
 end


### PR DESCRIPTION
Modern rubies permit an optional argument for retrieving singleton method names instead of the object methods. This feature is used by delegate.rb from the standard library now, which makes it impossible to have an EXIF data object delegated to since `methods()` gets called with a wrong
signature.

See https://ruby-doc.org/core-2.5.0/Object.html#method-i-methods