### PR TITLE
Does not raise error when it has invalid thumbails data (#65)

### DIFF
--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -384,7 +384,12 @@ module EXIFR
         @jpeg_thumbnails = @ifds.map do |v|
           if v.jpeg_interchange_format && v.jpeg_interchange_format_length
             start, length = v.jpeg_interchange_format, v.jpeg_interchange_format_length
-            data[start..(start + length)]
+            if Integer === start && Integer === length
+              data[start..(start + length)]
+            else
+              EXIFR.logger.warn("Non numeric JpegInterchangeFormat data")
+              nil
+            end
           end
         end.compact
       end


### PR DESCRIPTION
fix #65 

As I told you before, I don't have the permission, for now, to share the customer file, but I can show the test that I wrote here:

```ruby
# tests/jpeg_test.rb
def test_jpeg_broken_thumbnails
  fname = f('broken_thumbnails.jpg')
  j = JPEG.new(fname)

  assert_equal j.exif.jpeg_thumbnails.size, 0
end
```

I don't know how to generate a file to reproduce that error or even a good way to mock/stub a file for this test (I noticed that there are no mocks in the tests, which I like!)