### PR TITLE
Using require_relative to help using minitest

### DIFF
--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2006-2017 - R.W. van 't Veer
 
-require 'test_helper'
+require_relative 'test_helper'
 
 class JPEGTest < TestCase
   def test_initialize

--- a/tests/tiff_test.rb
+++ b/tests/tiff_test.rb
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2006-2017 - R.W. van 't Veer
 
-require 'test_helper'
+require_relative 'test_helper'
 
 class TIFFTest < TestCase
   def setup


### PR DESCRIPTION
Hi!

When I was doing #66 I was trying to find a way to run only 1 test scenario, like I am used to do with rspec.

Then, installed the gem `m`, tried to run only 1 scenario and got this error:

```bash
$ m tests/jpeg_test.rb:36
Failed loading test file:
cannot load such file -- test_helper
There were no tests found.
```

Then, I changed `require` by `require_relative` and I managed to run the way I wanted:
```bash
$ m tests/jpeg_test.rb:36
Run options: -n "/^(test_size)$/" --seed 40264

# Running:

.

Finished in 0.001608s, 621.8906 runs/s, 3731.3435 assertions/s.
1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

I'm not sure if there is a way to run a specific scenario with the gem `test-unit` which is the default for this project.

But I think the modification that I'm proposing will not affect anything.
