### PR TITLE
Makes it optional to load JPEG thumbnails from Tiff files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '1.9'
           - '2.0'
           - '2.1'
           - '2.2'

--- a/lib/exifr/jpeg.rb
+++ b/lib/exifr/jpeg.rb
@@ -29,11 +29,11 @@ module EXIFR
     attr_reader :app1s
 
     # +file+ is a filename or an IO object.  Hint: use StringIO when working with slurped data like blobs.
-    def initialize(file)
+    def initialize(file, load_thumbnails: true)
       if file.kind_of? String
-        File.open(file, 'rb') { |io| examine(io) }
+        File.open(file, 'rb') { |io| examine(io, load_thumbnails: load_thumbnails) }
       else
-        examine(file.dup)
+        examine(file.dup, load_thumbnails: load_thumbnails)
       end
     end
 
@@ -95,7 +95,7 @@ module EXIFR
       end
     end
 
-    def examine(io)
+    def examine(io, load_thumbnails: true)
       io = Reader.new(io)
 
       unless io.getbyte == 0xFF && io.getbyte == 0xD8 # SOI
@@ -121,7 +121,7 @@ module EXIFR
 
       if app1 = @app1s.find { |d| d[0..5] == "Exif\0\0" }
         @exif_data = app1[6..-1]
-        @exif = TIFF.new(StringIO.new(@exif_data))
+        @exif = TIFF.new(StringIO.new(@exif_data), load_thumbnails: load_thumbnails)
       end
     end
   end

--- a/lib/exifr/tiff.rb
+++ b/lib/exifr/tiff.rb
@@ -375,7 +375,7 @@ module EXIFR
     TAGS = [TAG_MAPPING.keys, TAG_MAPPING.values.map{|v|v.values}].flatten.uniq - IFD_TAGS
 
     # +file+ is a filename or an +IO+ object.  Hint: use +StringIO+ when working with slurped data like blobs.
-    def initialize(file, load_thumbnails = true)
+    def initialize(file, load_thumbnails: true)
       Data.open(file) do |data|
         @ifds = [IFD.new(data)]
         while ifd = @ifds.last.next

--- a/tests/jpeg_test.rb
+++ b/tests/jpeg_test.rb
@@ -127,6 +127,13 @@ class JPEGTest < TestCase
     assert count > 0, 'no thumbnails found'
   end
 
+  def test_skippable_thumbnail
+    all_test_jpegs.each do |fname|
+      jpeg = JPEG.new(fname, load_thumbnails: false)
+      assert jpeg.thumbnail.nil?
+    end
+  end
+
   def test_gps_with_altitude
     t = JPEG.new(f('gps-altitude.jpg'))
 

--- a/tests/tiff_test.rb
+++ b/tests/tiff_test.rb
@@ -190,7 +190,7 @@ class TIFFTest < TestCase
 
   def test_skippable_jpeg_thumbnails
     all_test_tiffs.each do |fname|
-      t = TIFF.new(fname, false)
+      t = TIFF.new(fname, load_thumbnails: false)
       assert t.jpeg_thumbnails.empty?
     end
   end

--- a/tests/tiff_test.rb
+++ b/tests/tiff_test.rb
@@ -188,6 +188,13 @@ class TIFFTest < TestCase
     assert count > 0, 'no thumbnails found'
   end
 
+  def test_skippable_jpeg_thumbnails
+    all_test_tiffs.each do |fname|
+      t = TIFF.new(fname, false)
+      assert t.jpeg_thumbnails.empty?
+    end
+  end
+
   def test_should_not_loop_endlessly
     TIFF.new(f('endless-loop.exif'))
     assert true


### PR DESCRIPTION
Hi

Some use cases of EXIFR don't actually require loading JPEG thumbnails from TIFF files.

As files are getting larger and larger recently, so are the thumbnails. This means we can save quite a lot of I/O operations in scenarios where these thumbnails are not necessary and throughput is critical.